### PR TITLE
Refresh session timestamp during custom message composition

### DIFF
--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -75,7 +75,16 @@ async def handle_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif action == "custom":
         updated_text = query.message.text + "\n\n📝 Please type your custom message now."
         await query.edit_message_text(updated_text)
-        await update_session_state(chat_id, message_id, awaiting_custom=True)
+        # Refresh the timestamp so the session doesn't expire while the admin
+        # types a custom response. Without this, the original timestamp from
+        # when the message was first sent would trigger a timeout even though
+        # the admin is actively composing a reply.
+        await update_session_state(
+            chat_id,
+            message_id,
+            awaiting_custom=True,
+            timestamp=asyncio.get_running_loop().time(),
+        )
 
     # Cleanup
     if action != "custom":


### PR DESCRIPTION
## Summary
- prevent session timeout while composing custom replies by updating session timestamp when admin opts to write a custom message

## Testing
- `pytest -q`
