### PR TITLE
Ensure custom replies are sent to the correct user

### DIFF
--- a/telegram_ai_bot.py
+++ b/telegram_ai_bot.py
@@ -74,11 +74,14 @@ async def handle_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif action == "custom":
         updated_text = query.message.text + "\n\n📝 Please type your custom message now."
         await query.edit_message_text(updated_text)
-        # Mark this session as awaiting a custom response from the admin.
+        # Mark this session as awaiting a custom response from the admin and
+        # record when the custom request was initiated. This timestamp is used
+        # to map the admin's next message to the correct resume.
         await update_session_state(
             chat_id,
             message_id,
             awaiting_custom=True,
+            timestamp=asyncio.get_running_loop().time(),
         )
 
     # Cleanup

--- a/utils/db.py
+++ b/utils/db.py
@@ -47,9 +47,16 @@ async def get_session(chat_id: int, message_id: int):
 
 
 async def get_pending_custom(chat_id: int):
+    """Return the most recent pending custom session for a chat."""
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
-            "SELECT message_id, resume_url FROM pending_sessions WHERE chat_id=? AND awaiting_custom=1",
+            """
+            SELECT message_id, resume_url
+            FROM pending_sessions
+            WHERE chat_id=? AND awaiting_custom=1
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """,
             (chat_id,),
         )
         row = await cursor.fetchone()


### PR DESCRIPTION
## Summary
- Track when admins choose a custom reply so follow-up messages target the intended resume
- Retrieve only the latest pending custom session for each admin to avoid misrouting messages

## Testing
- `python -m py_compile telegram_ai_bot.py utils/db.py utils/schemas.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ec814ed8832fa4e0fb1eba2e70db